### PR TITLE
Reset sha512

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Fix `Sha512.reset()` not clearing the `closed` flag (reusing a digest after `sum()` trapped)
 - Optimize `Sha512.reset()`
-- Add lifecycle benchmarks for Sha512  
+- Add lifecycle benchmarks for Sha512
 
 ## 0.2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Sha2 changelog
 
+## 0.2.4
+
+- Fix `Sha512.reset()` not clearing the `closed` flag (reusing a digest after `sum()` trapped)
+- Optimize `Sha512.reset()`
+
 ## 0.2.3
 
 - Add `Sha256.sumDouble()` for double SHA256 (the Bitcoin hash)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix `Sha512.reset()` not clearing the `closed` flag (reusing a digest after `sum()` trapped)
 - Optimize `Sha512.reset()`
+- Add lifecycle benchmarks for Sha512  
 
 ## 0.2.3
 

--- a/bench/sha512_lifecycle.bench.mo
+++ b/bench/sha512_lifecycle.bench.mo
@@ -1,0 +1,144 @@
+import Blob "mo:core/Blob";
+import Array "mo:core/Array";
+import VarArray "mo:core/VarArray";
+import Random "mo:core/Random";
+import Bench "mo:bench-helper";
+import Sha512 "../src/Sha512";
+import Digest512 "../src/sha512/digest"; // internal module exposing close()
+import Sha512_old "mo:sha2_0_1_14/Sha512"; // pinned 0.1.14 for comparison
+
+module {
+  public func init() : Bench.V1 {
+    let rows = [
+      "new()", // create a fresh hasher
+      "reset()", // reset an existing hasher
+      "sum()", // finalize and return the hash (allocates a Blob)
+      "close()", // internal finalize without returning (no allocation)
+      "merkle 2^12", // single-sha Merkle root over 4096 leaves
+    ];
+    let cols = [
+      "0.2.x (current)",
+      "0.1.14",
+    ];
+
+    let schema : Bench.Schema = {
+      name = "Sha512 lifecycle";
+      description = "Per-operation cost of the Sha512 hasher lifecycle, local code vs. pinned 0.1.14. The hasher in reset()/sum()/close() rows already exists and has had a partial block written to it. 0.1.14 has no public finalize-without-allocation, so its close() cell is a no-op (N/A). merkle 2^12 is a single-sha Merkle root over 4096 64-byte leaves (4095 sha512 steps), streamed with one reused hasher per level (12 levels) — no hasher is allocated per node.";
+      rows = rows;
+      cols = cols;
+    };
+
+    // A fixed, sub-block-size input (block size is 128 bytes) so the finalize
+    // rows exercise padding identically across versions.
+    let rng : Random.Random = Random.seed(0x5f5f5f5f5f5f5f5f);
+    let input : Blob = Blob.fromArray(Array.tabulate<Nat8>(80, func(i) = rng.nat8()));
+
+    // Pre-built hashers for the non-creation rows. Each cell runs exactly
+    // once per measurement, so a single finalize per hasher is safe.
+    let resetLocal = Sha512.new();
+    Sha512.writeBlob(resetLocal, input);
+    let sumLocal = Sha512.new();
+    Sha512.writeBlob(sumLocal, input);
+    let closeLocal = Sha512.new();
+    Sha512.writeBlob(closeLocal, input);
+
+    let resetOld = Sha512_old.Digest(#sha512);
+    resetOld.writeBlob(input);
+    let sumOld = Sha512_old.Digest(#sha512);
+    sumOld.writeBlob(input);
+
+    // 2^12 = 4096 leaves of 64 bytes (the sha512 digest size), so that
+    // concatenating two children is exactly one 128-byte block.
+    let leaves : [Blob] = Array.tabulate<Blob>(
+      4096,
+      func(_) = Blob.fromArray(Array.tabulate<Nat8>(64, func(i) = rng.nat8())),
+    );
+
+    // Number of tree levels = log2(leaf count). 4096 leaves -> 12 combining
+    // levels, so 12 hashers, one per level.
+    var levels = 0;
+    var n = leaves.size();
+    while (n > 1) { n /= 2; levels += 1 };
+
+    // Generic streaming Merkle root with single-sha per node: leaves are fed
+    // left to right and a single hasher per level is kept alive holding a
+    // pending left child until its right sibling arrives. No hasher is
+    // allocated per node.
+    func merkleStream<T>(
+      hashers : [T],
+      write : (T, Blob) -> (),
+      finalize : (T) -> Blob, // sha512 of all data written; closes the hasher
+      reopen : (T) -> (), // reset the hasher to accept the next pair
+    ) : Blob {
+      let pending = VarArray.repeat<Bool>(false, hashers.size());
+      var root : Blob = ""; // overwritten by the final combine
+
+      func push(node : Blob, lvl : Nat) {
+        if (lvl == hashers.size()) { root := node; return };
+        let h = hashers[lvl];
+        if (not pending[lvl]) {
+          // left child: keep it in this level's hasher until its sibling arrives
+          write(h, node);
+          pending[lvl] := true;
+        } else {
+          // right child: h now holds left ++ right; hash it and go up
+          write(h, node);
+          let parent = finalize(h);
+          reopen(h);
+          pending[lvl] := false;
+          push(parent, lvl + 1);
+        };
+      };
+
+      var i = 0;
+      while (i < leaves.size()) { push(leaves[i], 0); i += 1 };
+      root;
+    };
+
+    let merkleHashersLocal = Array.tabulate<Sha512.Digest>(levels, func(_) = Sha512.new());
+    let merkleHashersOld = Array.tabulate<Sha512_old.Digest>(levels, func(_) = Sha512_old.Digest(#sha512));
+
+    func merkleLocal() : Blob = merkleStream<Sha512.Digest>(
+      merkleHashersLocal,
+      func(h, b) = Sha512.writeBlob(h, b),
+      func(h) = Sha512.sum(h),
+      func(h) = Sha512.reset(h),
+    );
+    func merkleOld() : Blob = merkleStream<Sha512_old.Digest>(
+      merkleHashersOld,
+      func(h, b) = h.writeBlob(b),
+      func(h) = h.sum(),
+      func(h) = h.reset(),
+    );
+
+    let routines : [[() -> ()]] = [
+      // new()
+      [
+        func() = ignore Sha512.new(),
+        func() = ignore Sha512_old.Digest(#sha512),
+      ],
+      // reset()
+      [
+        func() = Sha512.reset(resetLocal),
+        func() = resetOld.reset(),
+      ],
+      // sum()
+      [
+        func() = ignore Sha512.sum(sumLocal),
+        func() = ignore sumOld.sum(),
+      ],
+      // close()
+      [
+        func() = Digest512.close(closeLocal),
+        func() {}, // N/A: 0.1.14 has no public finalize-without-allocation
+      ],
+      // merkle 2^12: single-sha Merkle root, one hasher per level
+      [
+        func() = ignore merkleLocal(),
+        func() = ignore merkleOld(),
+      ],
+    ];
+
+    Bench.V1(schema, func(ri : Nat, ci : Nat) = routines[ri][ci]());
+  };
+};

--- a/mops.toml
+++ b/mops.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha2"
-version = "0.2.3"
+version = "0.2.4"
 description = "Optimized implementation of all SHA2 functions"
 repository = "https://github.com/research-ag/sha2"
 keywords = [ "hash", "sha256", "sha512", "sha224", "sha384" ]

--- a/src/Sha512.mo
+++ b/src/Sha512.mo
@@ -143,9 +143,15 @@ module {
       case (#sha384) 2;
       case (#sha512) 3;
     };
-    for (j in [0, 1, 2, 3, 4, 5, 6, 7].vals()) {
-      self.s[j] := ivs[i][j];
+    // Unrolled IV copy avoids allocating the `[0..7]` index array and its
+    // iterator on every reset (cf. the Sha256 reset optimization).
+    let v = ivs[i];
+    // prettier-ignore
+    do {
+      self.s[0] := v[0]; self.s[1] := v[1]; self.s[2] := v[2]; self.s[3] := v[3];
+      self.s[4] := v[4]; self.s[5] := v[5]; self.s[6] := v[6]; self.s[7] := v[7];
     };
+    self.closed := false;
   };
 
   /// Create an independent copy of the digest with the same internal state.

--- a/test/reset.test.mo
+++ b/test/reset.test.mo
@@ -1,0 +1,23 @@
+import Sha256 "../src/Sha256";
+import Sha512 "../src/Sha512";
+
+// Regression: reset() must re-open a finalized (closed) digest so it can be
+// reused for a new message. Sha512.reset() previously forgot to clear the
+// `closed` flag, so the second writeBlob below trapped.
+for (algo in ([#sha256, #sha224] : [Sha256.Algorithm]).values()) {
+  let d = Sha256.new(algo);
+  d.writeBlob("first");
+  let h1 = d.sum(); // closes the digest
+  d.reset();
+  d.writeBlob("first");
+  assert (d.sum() == h1); // same input after reset -> same hash
+};
+
+for (algo in ([#sha512, #sha384, #sha512_224, #sha512_256] : [Sha512.Algorithm]).values()) {
+  let d = Sha512.new(algo);
+  d.writeBlob("first");
+  let h1 = d.sum(); // closes the digest
+  d.reset();
+  d.writeBlob("first");
+  assert (d.sum() == h1); // same input after reset -> same hash
+};


### PR DESCRIPTION
* Optimize reset() for Sha512
* bugfix: reset() did not re-open a closed Sha512 engine

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 0.2.4

* **Bug Fixes**
  * Fixed Sha512.reset() failing to re-open finalized digests after calling sum().

* **Performance**
  * Optimized Sha512.reset() with streamlined state initialization.

* **New Features**
  * Added comprehensive lifecycle benchmarks for Sha512 performance measurement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->